### PR TITLE
Expose const_generics feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 default = []
 mpio = ["mpi-sys", "hdf5-sys/mpio"]
 conda = ["hdf5-sys/conda"] 
+const_generics = ["hdf5-types/const_generics"]
 
 [workspace]
 members = [".", "hdf5-types", "hdf5-derive", "hdf5-sys", "hdf5-src"]


### PR DESCRIPTION
While we don't upgrade to (soon-to-be-released [`0.8.0`](https://github.com/aldanor/hdf5-rust/issues/152)) it is useful to have const generics available for arrays > 32kb