### PR TITLE
Add cargo:rerun-if- directives for conda feature.

### DIFF
--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -642,6 +642,8 @@ impl Config {
 fn main() {
     #[cfg(feature = "conda")]
     if env::var("CARGO_FEATURE_CONDA").is_ok() {
+        println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-env-changed=CARGO_FEATURE_CONDA");
         conda_dl::conda_static();
         return;
     }


### PR DESCRIPTION
Currently it isn't emitting them, leading to unecessary reruns of the
build script, which are especially expensive due to the download.