### PR TITLE
restore base package and zlib

### DIFF
--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -753,6 +753,16 @@ mod conda_dl {
                 "https://anaconda.org/conda-forge/hdf5-static/1.12.1/download/osx-arm64/hdf5-static-1.12.1-nompi_h18eddcc_102.tar.bz2",
                 "ee6e87b831eefdc5d7d5ec39705c94bbec55b0f1fc11058242fb18a462fb1484",
             ),
+            (
+                "hdf5-1.12.1-nompi_had0e5e0_101.tar.bz2",
+                "https://anaconda.org/conda-forge/hdf5/1.12.1/download/osx-arm64/hdf5-1.12.1-nompi_had0e5e0_101.tar.bz2",
+                "479a943c508ea796b708d4eaaa6bf03b5168c877a454190d67a75f28a44a2461",
+            ),
+            (
+                "zlib-1.2.11-hee7b306_1013.tar.bz2",
+                "https://anaconda.org/conda-forge/zlib/1.2.11/download/osx-arm64/zlib-1.2.11-hee7b306_1013.tar.bz2",
+                "04cbcc43aaf9b1ba31eddb0a93adb1a025156542fd4ba2b7b66b4ba4f4126d50",
+            ),
         ];
     }
 


### PR DESCRIPTION
required for headers and linking

I didn't catch this previously because I didn't `cargo clean`, let this stand as a reminder for future's sake!