### PR TITLE
Widen version range for attohttpc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/aldanor/hdf5-rust"
 homepage = "https://github.com/aldanor/hdf5-rust"
 build = "build.rs"
 edition = "2018"
+include = ["src/**/*", "Cargo.*", "LICENSE-*", "README.*", "CHANGELOG.md", "build.rs"]
 
 [features]
 default = []

--- a/hdf5-derive/Cargo.toml
+++ b/hdf5-derive/Cargo.toml
@@ -8,6 +8,7 @@ description = "Derive macro for HDF5 structs and enums."
 repository = "https://github.com/aldanor/hdf5-rust"
 homepage = "https://github.com/aldanor/hdf5-rust"
 edition = "2018"
+include = ["src/*.rs"]
 
 [lib]
 proc-macro = true

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -33,7 +33,7 @@ conda = ["attohttpc", "sha2", "bzip2", "tar"]
 libloading = "0.7"
 regex = { version = "1.3", features = ["std"] }
 sha2 = { version = ">=0.9, <0.11", optional = true }
-attohttpc = { version = ">=0.12, <0.20", default-features = false, features = ["compress", "tls-rustls"], optional = true }
+attohttpc = { version = ">=0.12, <0.23", default-features = false, features = ["compress", "tls-rustls"], optional = true }
 bzip2 = { version = ">=0.3.3, <0.5", optional = true }
 tar = { version = "*", optional = true }
 


### PR DESCRIPTION
Also add include directives to Cargo.toml to trim down the crate size a
little.