### PR TITLE
build(sys): turn off unneeded regex features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cfg-if = "1.0"
 paste = "1.0"
 pretty_assertions = "1.0"
 rand = { version = "0.8", features = ["small_rng"] }
-regex = "1.3"
+regex = { version = "1.3", default-features = false, features = ["std"] }
 scopeguard = "1.0"
 tempfile = "3.2"
 

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -31,7 +31,7 @@ conda = ["attohttpc", "sha2", "bzip2", "tar"]
 
 [build-dependencies]
 libloading = "0.7"
-regex = { version = "1.3", features = ["std"] }
+regex = { version = "1.3", default-features = false, features = ["std", "unicode-perl"] }
 sha2 = { version = ">=0.9, <0.11", optional = true }
 attohttpc = { version = ">=0.12, <0.25", default-features = false, features = ["compress", "tls-rustls"], optional = true }
 bzip2 = { version = ">=0.3.3, <0.5", optional = true }


### PR DESCRIPTION
regex is only needed as a build dependency, so we don't need the "perf" feature set.

We're only using it to match version numbers, so we don't need most of the "unicode" feature, either.

For the root hdf5 crate, it's only needed as a dev dependency, which needs even less.