### PR TITLE
build(deps): bump attohttpc from 0.26.1 to 0.28.0

### DIFF
--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -34,7 +34,7 @@ conda = ["attohttpc", "sha2", "bzip2", "tar"]
 libloading = "0.7"
 regex = { version = "1.3", default-features = false, features = ["std", "unicode-perl"] }
 sha2 = { version = ">=0.9, <0.11", optional = true }
-attohttpc = { version = ">=0.12, <0.27", default-features = false, features = ["compress", "tls-rustls"], optional = true }
+attohttpc = { version = ">=0.12, <1", default-features = false, features = ["compress", "tls-rustls"], optional = true }
 bzip2 = { version = ">=0.3.3, <0.5", optional = true }
 tar = { version = "*", optional = true }
 


### PR DESCRIPTION
Bump `attohttpc` from 0.26.1 to 0.27.0.
