### PR TITLE
ci: Add branch conda_nov2021 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - conda_nov2021
   pull_request:
     branches:
       - master
+      - conda_nov2021
   schedule:
     - cron: '0 18 * * *'
 


### PR DESCRIPTION
Add branch `conda_nov2021` to `.github/workflows/ci.yml`.
