### PR TITLE
feat: Remove feature dependency `attohttpc/tls-rustls`

### DIFF
--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -34,10 +34,9 @@ conda = ["attohttpc", "sha2", "bzip2", "tar"]
 libloading = ">=0.7,<1"
 regex = { version = "1.3", default-features = false, features = ["std", "unicode-perl"] }
 sha2 = { version = ">=0.9, <0.11", optional = true }
-attohttpc = { version = ">=0.12, <1", default-features = false, features = ["compress", "tls-rustls"], optional = true }
+attohttpc = { version = ">=0.12, <1", default-features = false, features = ["compress"], optional = true }
 bzip2 = { version = ">=0.3.3, <0.5", optional = true }
 tar = { version = "*", optional = true }
-
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
Let the dependent choose between `tls-rustls-webpki-roots` and `tls-rustls-webpki-roots-ring`
